### PR TITLE
fixed force https for apache on server

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -6,8 +6,8 @@
     RewriteEngine On
 
     # Force https
-    RewriteCond %{HTTP:X-Forwarded-Proto} !https
-    RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+    RewriteCond %{HTTPS} !on
+    RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
 
     # Handle Authorization Header
     RewriteCond %{HTTP:Authorization} .


### PR DESCRIPTION
Issue: https://github.com/drewwmercer/eastbayloop/issues/24
The previous version works fine on my local machine, but on DigitalOcean it worked with redirects loop. I changed .htacces on DigitalOcean to fix that and now added same fixes into git here.
maybe need use command `git reset --hard` if `git pull` was not working, because on the server and this commit was same changes